### PR TITLE
fix(build): ensure static libstdc++ linking by patching conan deps

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -1068,6 +1068,11 @@ target_link_libraries (rippled
   Ripple::opts
   Ripple::libs
   Ripple::xrpl_core
+  # Workaround for a Conan 1.x bug that prevents static linking of libstdc++
+  # when a dependency (snappy) modifies system_libs. See the comment in
+  # external/snappy/conanfile.py for a full explanation.
+  # This is likely not strictly necessary, but listed explicitly as a good practice.
+  m
   )
 exclude_if_included (rippled)
 # define a macro for tests that might need to

--- a/build-core.sh
+++ b/build-core.sh
@@ -45,7 +45,7 @@ export CMAKE_STATIC_LINKER_FLAGS="-static-libstdc++"
 git config --global --add safe.directory /io &&
 git checkout src/ripple/protocol/impl/BuildInfo.cpp &&
 sed -i s/\"0.0.0\"/\"$(date +%Y).$(date +%-m).$(date +%-d)-$(git rev-parse --abbrev-ref HEAD)$(if [ -n "$4" ]; then echo "+$4"; fi)\"/g src/ripple/protocol/impl/BuildInfo.cpp &&
-conan export external/snappy snappy/1.1.9@ &&
+conan export external/snappy snappy/1.1.10@ &&
 conan export external/soci soci/4.0.3@ &&
 cd release-build &&
 conan install .. --output-folder . --build missing --settings build_type=$BUILD_TYPE &&

--- a/external/snappy/conanfile.py
+++ b/external/snappy/conanfile.py
@@ -77,9 +77,14 @@ class SnappyConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "Snappy::snappy")
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["snappylib"].libs = ["snappy"]
-        if not self.options.shared:
-            if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["snappylib"].system_libs.append("m")
+        # The following block is commented out as a workaround for a bug in the
+        # Conan 1.x CMakeDeps generator. Including system_libs ("m") here
+        # incorrectly triggers a heuristic that adds a dynamic link to `stdc++`
+        # (-lstdc++), preventing a fully static build.
+        # This behavior is expected to be corrected in Conan 2.
+        # if not self.options.shared:
+        #     if self.settings.os in ["Linux", "FreeBSD"]:
+        #         self.cpp_info.components["snappylib"].system_libs.append("m")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "Snappy"


### PR DESCRIPTION
This commit resolves an issue where the xahaud binary was dynamically
linking against libstdc++ despite build flags requesting static linkage.

The root cause was a bug in the Conan 1.x CMakeDeps generator,
triggered by the snappy recipe modifying `system_libs`. This caused
Conan to inject `-lstdc++` into the build, overriding other settings.

The fix involves three parts:
1. snappy/conanfile.py: The trigger for the bug is removed by
   commenting out the modification of `system_libs`.
2. RippledCore.cmake: The math library (`libm`) is now explicitly
   linked to the final executable target as a best practice.
3. build-core.sh: The conan export for snappy is updated to the
   correct version.