### PR TITLE
Fix HookOn v2 direction-only updates

### DIFF
--- a/src/test/app/SetHook_test.cpp
+++ b/src/test/app/SetHook_test.cpp
@@ -1661,6 +1661,28 @@ public:
             env.fund(XRP(10000), alice, bob);
             env.close();
 
+            TER const expected =
+                env.current()->rules().enabled(fixHookOnV2InstallUpdate)
+                ? TER(temMALFORMED)
+                : TER(tesSUCCESS);
+
+            for (auto const& key : {jss::HookOnIncoming, jss::HookOnOutgoing})
+            {
+                auto noopJv = Json::Value{};
+                noopJv[key] =
+                    "fffffffffffffffffffffffffffffffffffffff7ffffffffffffffffff"
+                    "bfffff";
+
+                env(ripple::test::jtx::hook(alice, {{noopJv}}, 0),
+                    M("Lone direction HookOn NOOP"),
+                    HSFEE,
+                    ter(expected));
+                env.close();
+
+                if (!withFix)
+                    BEAST_EXPECT(!env.le(keylet::hook(alice)));
+            }
+
             // 1. Create Hook with HookOnIncoming/Outgoing to alice
             auto jv = hso(accept_wasm);
             jv.removeMember(jss::HookOn);
@@ -1672,11 +1694,6 @@ public:
                 "bffffe";  // Payment high
             env(ripple::test::jtx::hook(alice, {{jv}}, 0), HSFEE);
             env.close();
-
-            TER const expected =
-                env.current()->rules().enabled(fixHookOnV2InstallUpdate)
-                ? TER(temMALFORMED)
-                : TER(tesSUCCESS);
 
             // 2. Install Hook with HookOn, Incoming/Outgoing to bob
             jv = Json::Value{};

--- a/src/xrpld/app/tx/detail/SetHook.cpp
+++ b/src/xrpld/app/tx/detail/SetHook.cpp
@@ -312,6 +312,12 @@ SetHook::validateHookSetEntry(SetHookCtx& ctx, STObject const& hookSetObj)
     switch (inferOperation(hookSetObj))
     {
         case hsoNOOP: {
+            if (ctx.rules.enabled(fixHookOnV2InstallUpdate) &&
+                (hookSetObj.isFieldPresent(sfHookOnOutgoing) ||
+                 hookSetObj.isFieldPresent(sfHookOnIncoming)) &&
+                !validateHookOn(ctx, hookSetObj))
+                return false;
+
             return true;
         }
 
@@ -1391,6 +1397,7 @@ SetHook::setHook()
         std::optional<ripple::Keylet> newDirKeylet;
 
         std::optional<uint256> newHookOn;
+        // Empty for HookOnV2 direction-only definitions.
         std::optional<uint256> defHookOn;
 
         std::optional<uint256> newHookOnOutgoing;
@@ -1662,7 +1669,7 @@ SetHook::setHook()
                 // set the hookon field if it differs from definition
                 if (newHookOn)
                 {
-                    if (*defHookOn == *newHookOn)
+                    if (defHookOn.has_value() && *defHookOn == *newHookOn)
                     {
                         if (newHook.isFieldPresent(sfHookOn))
                             newHook.makeFieldAbsent(sfHookOn);


### PR DESCRIPTION
Summary:
- validate HookOn v2 direction-only fields in the NOOP path
- avoid dereferencing an empty defHookOn optional during updates
- document why defHookOn may be empty for direction-only definitions

Tests:
- x-run-tests --reconfigure-build --stop-on-fail -- SetHook7
- x-run-tests --no-build --stop-on-fail -- SetHook